### PR TITLE
Image url uses finalUrl host component rather than its full path

### DIFF
--- a/Sources/SwiftLinkPreview.swift
+++ b/Sources/SwiftLinkPreview.swift
@@ -326,8 +326,14 @@ extension SwiftLinkPreview {
                             
                             if !value.extendedTrim.isEmpty && !value.hasPrefix("https://") && !value.hasPrefix("http://") && !value.hasPrefix("ftp://") {
                                 
-                                value = (value.hasPrefix("//") ? "http:" : (self.result["finalUrl"] as! NSURL).absoluteString) + value
-                                
+                                if let host = (self.result["finalUrl"] as! NSURL).host as String! {
+                                    if value.hasPrefix("//") {
+                                        value = (self.result["finalUrl"] as! NSURL).scheme + ":" + value
+                                    }
+                                    else {
+                                        value = (self.result["finalUrl"] as! NSURL).scheme + "://" + host + value
+                                    }
+                                }
                             }
                             
                             imgs.append(value)


### PR DESCRIPTION
urls such as http://supervalue.co.nz/neighbourly/index.php?option=com_content&view=article&id=902&utm_form=npost would result in image urls like this:

http://supervalue.co.nz/neighbourly/index.php?option=com_content&view=article&id=902&utm_form=npost/images/documents/neighbourly-0716/Neighbouly-Bag-wModel-SV.png which fails to load the image

Because the path and parameters weren't being stripped out. Ive changed to just use the finalUrl host + image path

<!-- Thanks for contributing to SwiftLinkPreview 😀 -->

<!--- Please follow the guideline below for a better maintenance -->

<!-- Change the action with the following types: Added|Removed|Updated|Fixed or something alike. Group them by type. -->
#### Updated 

<!-- If there are issues related to your PR, besides adding a brief description, add the issues' number. -->
- Add a brief description of what was made
	- Issues: #issue-number #issue-number ...
	- Commits: #commit-hash ...
- ...