### PR TITLE
Changed name of Objective-C compatible preview method wrapper to reso…

### DIFF
--- a/Sources/SwiftLinkPreview.swift
+++ b/Sources/SwiftLinkPreview.swift
@@ -157,7 +157,7 @@ open class SwiftLinkPreview : NSObject {
       images
      
      */
-    @objc @discardableResult open func preview(_ text: String!, onSuccess: @escaping (Dictionary<String, Any>) -> Void, onError: @escaping (NSError) -> Void) -> Cancellable {
+    @objc @discardableResult open func previewLink(_ text: String!, onSuccess: @escaping (Dictionary<String, Any>) -> Void, onError: @escaping (NSError) -> Void) -> Cancellable {
         
         func success (_ result : Response) -> Void {
             var ResponseData = [String : Any]()


### PR DESCRIPTION
…lve ambiguous method error in Swift builds


#### Renamed 

Renamed the Objective-C compatible wrapper fro the preview method to previewLink.
This resolves ambiguous method errors in Swift builds - issue #41 

<!-- If there are issues related to your PR, besides adding a brief description, add the issues' number. -->
- Resolve method name ambiguity for Swift builds
	- Issues: #41 .