### PR TITLE
use data detector to extract URLs from text so that plain urls will b…

### DIFF
--- a/Sources/SwiftLinkPreview.swift
+++ b/Sources/SwiftLinkPreview.swift
@@ -195,11 +195,15 @@ extension SwiftLinkPreview {
 
     // Extract first URL from text
     open func extractURL(text: String) -> URL? {
-        let pieces: [String] = text.components(separatedBy: .whitespacesAndNewlines).filter { $0.trim.isValidURL() }
-        if pieces.count > 0, let url = URL(string: pieces[0]) {
-            return url
+        do {
+            let detector = try NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+            let range = NSRange(location: 0, length: text.characters.count)
+            let matches = detector.matches(in: text, options: [], range: range)
+
+            return matches.flatMap { $0.url }.first
+        } catch {
+            return nil
         }
-        return nil
     }
 
     // Unshorten URL by following redirections

--- a/SwiftLinkPreviewTests/URLs.swift
+++ b/SwiftLinkPreviewTests/URLs.swift
@@ -16,7 +16,7 @@ struct URLs {
     static let bunch = [
         [
             "aaa www.google.com aaa",
-            "www.google.com",
+            "http://www.google.com",
             "www.google.com"
         ],
         [
@@ -36,12 +36,12 @@ struct URLs {
         ],
         [
             "ddd ios.leocardz.com/swift-link-preview/ ddd",
-            "ios.leocardz.com/swift-link-preview/",
+            "http://ios.leocardz.com/swift-link-preview/",
             "ios.leocardz.com"
         ],
         [
             "ddd ios.leocardz.com ddd",
-            "ios.leocardz.com",
+            "http://ios.leocardz.com",
             "ios.leocardz.com"
         ],
         [
@@ -51,7 +51,7 @@ struct URLs {
         ],
         [
             "fff theverge.com/2016/6/21/11996280/tesla-offer-solar-city-buy fff",
-            "theverge.com/2016/6/21/11996280/tesla-offer-solar-city-buy",
+            "http://theverge.com/2016/6/21/11996280/tesla-offer-solar-city-buy",
             "theverge.com"
         ],
         [
@@ -71,7 +71,7 @@ struct URLs {
         ],
         [
             "hhh twitter.com hhh",
-            "twitter.com",
+            "http://twitter.com",
             "twitter.com"
         ],
         [


### PR DESCRIPTION
replaced link detection with NSDataDetector  was seeing situations where app was unable to load previews for text containing links of the form "text text github.com" for example 