### PR TITLE
Fixed: Missing underscore in IBAction method signature / SIGABRT crashes

### DIFF
--- a/Example/SwiftLinkPreviewExample.xcodeproj/project.pbxproj
+++ b/Example/SwiftLinkPreviewExample.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 48;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -192,7 +192,7 @@
 				};
 			};
 			buildConfigurationList = 98846C721D09AA1B00846726 /* Build configuration list for PBXProject "SwiftLinkPreviewExample" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 8.0";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -361,7 +361,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -409,7 +409,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -424,7 +424,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = T99T2WGRY2;
 				INFOPLIST_FILE = SwiftLinkPreviewExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.leocardz.SLPExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -442,7 +442,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = T99T2WGRY2;
 				INFOPLIST_FILE = SwiftLinkPreviewExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.leocardz.SLPExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Example/SwiftLinkPreviewExample/Controllers/ViewController.swift
+++ b/Example/SwiftLinkPreviewExample/Controllers/ViewController.swift
@@ -286,12 +286,12 @@ class ViewController: UIViewController {
         
     }
     
-    @IBAction func openWithAction(sender: UIButton) {
+    @IBAction func openWithAction(_ sender: UIButton) {
         
-        if let url: NSURL = self.result[.finalUrl] as? NSURL {
-            
-            UIApplication.shared.openURL(url as URL)
-            
+        if let url = self.result[.finalUrl] as? URL {
+
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+
         }
         
     }


### PR DESCRIPTION
Fixed : Issue #68 

- insert missing underscore in IBAction `openWithAction` method signature


Updated :

- replace deprecated method`openURL(_:)` with `open(_:options:completionHandler:)`

