### PR TITLE
Missing Accept header when requesting HTML.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 
 ---
 
+## 2.4.0
+
+#### Changed
+
+- Fixed missing Accept header
+
 ## [2.3.0](https://github.com/LeonardoCardoso/Swift-Link-Preview/releases/tag/2.3.0)
 Released on 2018-06-07.
 

--- a/Sources/NSURLSessionExtension.swift
+++ b/Sources/NSURLSessionExtension.swift
@@ -9,8 +9,7 @@ import Foundation
 
 public extension URLSession {
     
-    // Synchronous request to get the real URL
-    public func synchronousDataTaskWithURL(_ url: URL) -> (Data?, URLResponse?, NSError?) {
+    public func synchronousDataTask(with url: URL) -> (Data?, URLResponse?, NSError?) {
         
         var data: Data?, response: URLResponse?, error: NSError?
         let semaphore = DispatchSemaphore(value: 0)
@@ -25,7 +24,25 @@ public extension URLSession {
         _ = semaphore.wait(timeout: DispatchTime.distantFuture)
         
         return (data, response, error)
-        
+
     }
-    
+
+    public func synchronousDataTask(with request: URLRequest) -> (Data?, URLResponse?, NSError?) {
+
+        var data: Data?, response: URLResponse?, error: NSError?
+        let semaphore = DispatchSemaphore(value: 0)
+
+        dataTask(with: request, completionHandler: {
+
+            data = $0; response = $1; error = $2 as NSError?
+            semaphore.signal()
+
+            }) .resume()
+
+        _ = semaphore.wait(timeout: DispatchTime.distantFuture)
+
+        return (data, response, error)
+
+    }
+
 }


### PR DESCRIPTION
#### Fixed
When requesting HTML from certain sites (eg. https://www.uber.com/), the response is 404 unless the `Accept` header specifies that the UA is looking for HTML.

#### Fixed
When decoding the data from the response, don't guess, use the response's text encoding.

#### Added
The `NSURLSession` extension has a URL-based `synchronousDataTask`, but was missing an URLRequest-based equivalent (this is necessary for passing the request header).

I also noticed that this extension was actually not used before?