### PR TITLE
Swift 5 migration and Xcode 10.2 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 #### 3.x Releases
+- `3.1.x` Releases - [3.1.0](#302)
 - `3.0.x` Releases - [3.0.0](#300) | [3.0.1](#301)
 
 #### 2.x Releases
@@ -17,6 +18,12 @@
 - `0.0.x` Releases - [0.0.2](#002) | [0.0.3](#003)
 
 ---
+## [3.1.0](https://github.com/LeonardoCardoso/Swift-Link-Preview/releases/tag/3.1.0)
+
+#### Added
+
+- Changes for Swift 5 compatibility
+    - Added by [Rajesh](https://github.com/rajeshbeats)
 
 ## [3.0.1](https://github.com/LeonardoCardoso/Swift-Link-Preview/releases/tag/3.0.1)
 

--- a/Sources/NSURLSessionExtension.swift
+++ b/Sources/NSURLSessionExtension.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public extension URLSession {
 
-    public func synchronousDataTask(with url: URL) -> (Data?, URLResponse?, NSError?) {
+    func synchronousDataTask(with url: URL) -> (Data?, URLResponse?, NSError?) {
 
         var data: Data?, response: URLResponse?, error: NSError?
         let semaphore = DispatchSemaphore(value: 0)
@@ -27,7 +27,7 @@ public extension URLSession {
 
     }
 
-    public func synchronousDataTask(with request: URLRequest) -> (Data?, URLResponse?, NSError?) {
+    func synchronousDataTask(with request: URLRequest) -> (Data?, URLResponse?, NSError?) {
 
         var data: Data?, response: URLResponse?, error: NSError?
         let semaphore = DispatchSemaphore(value: 0)

--- a/Sources/ResponseExtension.swift
+++ b/Sources/ResponseExtension.swift
@@ -10,7 +10,7 @@ import Foundation
 
 internal extension Response {
     
-    internal var dictionary: [String: Any] {
+    var dictionary: [String: Any] {
         var responseData:[String: Any] = [:]
         responseData["url"] = url
         responseData["finalUrl"] = finalUrl
@@ -25,7 +25,7 @@ internal extension Response {
         return responseData
     }
     
-    internal enum Key: String {
+    enum Key: String {
         case url
         case finalUrl
         case canonicalUrl
@@ -38,7 +38,7 @@ internal extension Response {
         case price
     }
     
-    internal mutating func set(_ value: Any, for key: Key) {
+    mutating func set(_ value: Any, for key: Key) {
         switch key {
         case Key.url:
             if let value = value as? URL { self.url = value }
@@ -63,7 +63,7 @@ internal extension Response {
         }
     }
     
-    internal func value(for key: Key) -> Any? {
+    func value(for key: Key) -> Any? {
         switch key {
         case Key.url:
             return self.url

--- a/Sources/SwiftLinkPreview.swift
+++ b/Sources/SwiftLinkPreview.swift
@@ -169,7 +169,7 @@ open class SwiftLinkPreview: NSObject {
 
             if let range = absoluteString.range(of: "&"),
                 let firstChar = absoluteString.first,
-                let firstCharIndex = absoluteString.index(of: firstChar) {
+                let firstCharIndex = absoluteString.firstIndex(of: firstChar) {
                 absoluteString = String(absoluteString[firstCharIndex ..< absoluteString.index(before: range.upperBound)])
 
                 if let decoded = absoluteString.removingPercentEncoding, let newURL = URL(string: decoded) {
@@ -627,7 +627,7 @@ extension SwiftLinkPreview {
 
         var image = image
 
-        if let index = image.index(of: "?") { image = String(image[..<index]) }
+        if let index = image.firstIndex(of: "?") { image = String(image[..<index]) }
 
         return image
 

--- a/SwiftLinkPreview.xcodeproj/project.pbxproj
+++ b/SwiftLinkPreview.xcodeproj/project.pbxproj
@@ -568,7 +568,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = leocardz.com;
 				TargetAttributes = {
 					98846C951D09AA6E00846726 = {
@@ -581,9 +581,11 @@
 					};
 					98E7C2F31D3B2300009E5F6D = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 1020;
 					};
 					98E7C2FC1D3B2300009E5F6D = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 1020;
 					};
 					98F76CE11D3AF6DA00E9B10E = {
 						CreatedOnToolsVersion = 7.3.1;
@@ -593,15 +595,17 @@
 					};
 					98F76D2E1D3B1C3100E9B10E = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 1020;
 					};
 				};
 			};
 			buildConfigurationList = 98846C901D09AA6E00846726 /* Build configuration list for PBXProject "SwiftLinkPreview" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 98846C8C1D09AA6E00846726;
 			productRefGroup = 98846C971D09AA6E00846726 /* Products */;
@@ -856,6 +860,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -906,7 +911,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "armv7 arm64 armv7s";
 				VERSIONING_SYSTEM = "apple-generic";
@@ -918,6 +923,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -961,7 +967,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VALID_ARCHS = "armv7 arm64 armv7s";
@@ -989,7 +995,7 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				VALID_ARCHS = "armv7 arm64 armv7s";
 			};
 			name = Debug;
@@ -1012,7 +1018,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				VALID_ARCHS = "armv7 arm64 armv7s";
 			};
 			name = Release;
@@ -1028,7 +1034,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SwiftLinkPreviewTests/SwiftLinkPreviewTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1042,7 +1048,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.leocardz.SwiftLinkPreviewTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "SwiftLinkPreviewTests/SwiftLinkPreviewTests-Bridging-Header.h";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -1063,7 +1069,7 @@
 				PRODUCT_NAME = SwiftLinkPreview;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Debug;
@@ -1085,7 +1091,7 @@
 				PRODUCT_NAME = SwiftLinkPreview;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Release;
@@ -1100,7 +1106,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.leocardz.SwiftLinkPreview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Debug;
@@ -1115,7 +1121,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.leocardz.SwiftLinkPreview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Release;
@@ -1135,7 +1141,7 @@
 				PRODUCT_NAME = SwiftLinkPreview;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.2;
 			};
@@ -1156,7 +1162,7 @@
 				PRODUCT_NAME = SwiftLinkPreview;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.2;
 			};
@@ -1171,7 +1177,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.leocardz.SwiftLinkPreviewTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TVOS_DEPLOYMENT_TARGET = 9.2;
 			};
 			name = Debug;
@@ -1185,7 +1191,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.leocardz.SwiftLinkPreviewTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TVOS_DEPLOYMENT_TARGET = 9.2;
 			};
 			name = Release;
@@ -1206,7 +1212,7 @@
 				PRODUCT_NAME = SwiftLinkPreview;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				VALID_ARCHS = "arm64 armv7 armv7k armv7s";
 				WATCHOS_DEPLOYMENT_TARGET = 2.2;
@@ -1229,7 +1235,7 @@
 				PRODUCT_NAME = SwiftLinkPreview;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				VALID_ARCHS = "arm64 armv7 armv7k armv7s";
 				WATCHOS_DEPLOYMENT_TARGET = 2.2;

--- a/SwiftLinkPreview.xcodeproj/xcshareddata/xcschemes/SwiftLinkPreview.xcscheme
+++ b/SwiftLinkPreview.xcodeproj/xcshareddata/xcschemes/SwiftLinkPreview.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SwiftLinkPreview.xcodeproj/xcshareddata/xcschemes/SwiftLinkPreviewMacOS.xcscheme
+++ b/SwiftLinkPreview.xcodeproj/xcshareddata/xcschemes/SwiftLinkPreviewMacOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SwiftLinkPreview.xcodeproj/xcshareddata/xcschemes/SwiftLinkPreviewTvOS.xcscheme
+++ b/SwiftLinkPreview.xcodeproj/xcshareddata/xcschemes/SwiftLinkPreviewTvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SwiftLinkPreview.xcodeproj/xcshareddata/xcschemes/SwiftLinkPreviewWatchOS.xcscheme
+++ b/SwiftLinkPreview.xcodeproj/xcshareddata/xcschemes/SwiftLinkPreviewWatchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SwiftLinkPreviewTests/IntExtension.swift
+++ b/SwiftLinkPreviewTests/IntExtension.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public extension Int {
 
-    public static func random(_ lower: Int = 0, upper: Int = 100) -> Int {
+    static func random(_ lower: Int = 0, upper: Int = 100) -> Int {
         return lower + Int(arc4random_uniform(UInt32(upper - 1 - lower + 1)))
     }
 


### PR DESCRIPTION
This PR addressed Swift 5.0 migration and Xcode 10.2 compatibility changes.

Changes : 
String api change `index(of:) `to `firstIndex(of:)`
Removed `public` and `intern` use


