### PR TITLE
Add Support For Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,13 +1,15 @@
-//
-//  Package.swift
-//  SwiftLinkPreview
-//
-//  Created by Leonardo Cardoso on 04/07/2016.
-//  Copyright © 2016 leocardz.com. All rights reserved.
-//
-
+// swift-tools-version:5.1
 import PackageDescription
 
 let package = Package(
-    name: "SwiftLinkPreview"
+    name: "SwiftLinkPreview",
+    platforms: [
+        .iOS(.v8),
+    ],
+    products: [
+        .library(name: "SwiftLinkPreview", targets: ["SwiftLinkPreview"]),
+    ],
+    targets: [
+        .target(name: "SwiftLinkPreview", path: "Sources")
+    ]
 )


### PR DESCRIPTION
#### Updated 
- `Package.swift` to follow the schema required to use Swift Package Manager for iOS projects in XCode 11