### PR TITLE
Fixed package.swift to work in Xcode 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@
 - `0.0.x` Releases - [0.0.2](#002) | [0.0.3](#003)
 
 ---
+
+#### Changed
+- Updated Package.swift to swift-tools-version:4.2
+  - Changed by [skunkworker](https://github.com/skunkworker)
+
+
 ## [3.1.0](https://github.com/LeonardoCardoso/Swift-Link-Preview/releases/tag/3.1.0)
 
 #### Changed

--- a/Package.swift
+++ b/Package.swift
@@ -11,9 +11,13 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftLinkPreview",
-    platforms: [.iOS(.v8)],
     products: [
       .library(name: "SwiftLinkPreview",
                targets: ["SwiftLinkPreview"])
+    ],
+    targets: [
+      .target(
+        name: "SwiftLinkPreview",
+        dependencies: [])
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,4 @@
+// swift-tools-version:4.2
 //
 //  Package.swift
 //  SwiftLinkPreview
@@ -9,5 +10,10 @@
 import PackageDescription
 
 let package = Package(
-    name: "SwiftLinkPreview"
+    name: "SwiftLinkPreview",
+    platforms: [.iOS(.v8)],
+    products: [
+      .library(name: "SwiftLinkPreview",
+               targets: ["SwiftLinkPreview"])
+    ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
     targets: [
       .target(
         name: "SwiftLinkPreview",
-        dependencies: [])
+        dependencies: [],
+        path: "Sources")
     ]
 )


### PR DESCRIPTION
- Added version 4.2 for swift tools and updated manifest.
	- Issues: https://github.com/LeonardoCardoso/SwiftLinkPreview/issues/117