### PR TITLE
Fixes the NSRange to use a String defined range instead of inferring length from the count property

### DIFF
--- a/Sources/Regex.swift
+++ b/Sources/Regex.swift
@@ -40,9 +40,9 @@ class Regex {
 
             let rx = try NSRegularExpression(pattern: regex, options: [.caseInsensitive])
 
-            if let match = rx.firstMatch(in: string, options: [], range: NSRange(location: 0, length: string.count)) {
+            if let match = rx.firstMatch(in: string, options: [], range:NSRange(string.startIndex..., in: string)) {
 
-                var result: [String] = Regex.stringMatches([match], text: string, index: index)
+                let result: [String] = Regex.stringMatches([match], text: string, index: index)
                 return result.count == 0 ? nil : result[0]
 
             } else {
@@ -72,10 +72,10 @@ class Regex {
 
             if string.count > limit {
                 string.split(by: limit).forEach {
-                    matches.append(contentsOf: rx.matches(in: string, options: [], range: NSRange(location: 0, length: $0.count)))
+                    matches.append(contentsOf: rx.matches(in: string, options: [], range: NSRange($0.startIndex..., in: $0)))
                 }
             } else {
-                matches.append(contentsOf: rx.matches(in: string, options: [], range: NSRange(location: 0, length: string.count)))
+                matches.append(contentsOf: rx.matches(in: string, options: [], range: NSRange(string.startIndex..., in: string)))
             }
 
             return !matches.isEmpty ? Regex.stringMatches(matches, text: string, index: index) : []


### PR DESCRIPTION
### Fixed

`String.count` shouldn't be used to create `NSRange`. See the comment on https://stackoverflow.com/questions/27880650/swift-extract-regex-matches#comment110787889_54900097

> Be careful with above solution: `NSMakeRange(0, self.count)` is not correct, because `self` is a `String` (=UTF8) and not an `NSString` (=UTF16). So the `self.count` is not necessarily the same as `nsString.length` (as used in other solutions). You can replace the range calculation with `NSRange(self.startIndex..., in: self)` – pd95 Jun 29 at 22:27

Thanks for the great repo!