### PR TITLE
Correctly rebase relative image URLs from the final URL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 
 ---
 
+#### Changed
+- Resolve relative image URLs against the request URL.
+  	- Changed by [lhunath](https://github.com/lhunath)
+
 ## [3.3.0](https://github.com/LeonardoCardoso/Swift-Link-Preview/releases/tag/3.3.0)
 
 #### Changed

--- a/Sources/SwiftLinkPreview.swift
+++ b/Sources/SwiftLinkPreview.swift
@@ -678,8 +678,8 @@ extension SwiftLinkPreview {
         var image = image
 
         // TODO: account for HTML <base>
-        if let canonicalUrl = canonicalUrl, let finalUrl = finalUrl {
-            if image.hasPrefix("/"), let proto = finalUrl.split(separator: ":").first {
+        if let canonicalUrl = canonicalUrl, let finalUrl = finalUrl, let proto = finalUrl.split(separator: ":").first {
+            if image.hasPrefix("/") {
                 if image.hasPrefix("//") {
                     // image url is //domain/path
                     image = proto + ":" + image

--- a/Sources/SwiftLinkPreview.swift
+++ b/Sources/SwiftLinkPreview.swift
@@ -679,20 +679,26 @@ extension SwiftLinkPreview {
 
         // TODO: account for HTML <base>
         if let canonicalUrl = canonicalUrl, let finalUrl = finalUrl {
-            if finalUrl.hasPrefix("https:") {
+            if image.hasPrefix("/"), let proto = finalUrl.split(separator: ":").first {
                 if image.hasPrefix("//") {
-                    image = "https:" + image
-                } else if image.hasPrefix("/") {
-                    image = "https://" + canonicalUrl + image
+                    // image url is //domain/path
+                    image = proto + ":" + image
+                } else {
+                    // image url is /path relative to base url
+                    image = proto + "://" + canonicalUrl + image
                 }
-            } else if image.hasPrefix("//") {
-                image = "http:" + image
-            } else if image.hasPrefix("/") {
-                image = "http://" + canonicalUrl + image
+            } else if !image.contains("://") {
+                // image is relative to request url
+                let requestUrl = removeSuffixIfNeeded(finalUrl)
+                if requestUrl.hasSuffix("/") {
+                    image = requestUrl + image
+                } else {
+                    image = (requestUrl as NSString).deletingLastPathComponent + "/" + image
+                }
             }
         }
 
-        return removeSuffixIfNeeded(image)
+        return image
 
     }
 


### PR DESCRIPTION
#### Fixed 

- Relative image URLs are returned as relative String paths.

For them to be valid URLs that the application can use to request the actual image, they need to be resolved against the original request URL.

eg.

finalURL: "https://foo.com/quux/help.htm?s=x", image: "img/photo.jpg" -> image: "https://foo.com/quux/img/photo.jpg"