### PR TITLE
Fix parse the content for openGraph image for github

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
   	- Changed by [lhunath](https://github.com/lhunath)
 - fixed youtube and open graph tags image metadata issues
   	- Changed by [nafis042](https://github.com/nafis042)
+- Fixed github link image for `og:image` property.
+  	- Changed by [MuhtasimTanmoy](https://github.com/MuhtasimTanmoy/)
 
 ## [3.2.0](https://github.com/LeonardoCardoso/Swift-Link-Preview/releases/tag/3.2.0)
 

--- a/Sources/Regex.swift
+++ b/Sources/Regex.swift
@@ -11,6 +11,7 @@ import Foundation
 class Regex {
 
     static let imagePattern = "(.+?)\\.(gif|jpg|jpeg|png|bmp)$"
+    static let openGraphImagePattern = "(.+?)\\.(gif||jpg|jpeg|png|bmp)$"
     static let videoTagPattern = "<video[^>]+src=\"([^\"]+)"
     static let secondaryVideoTagPattern = "og:video\" content=\"([^\"](.+?))\"(.+?)[/]?>"
     static let imageTagPattern = "<img(.+?)src=\"([^\"](.+?))\"(.+?)[/]?>"

--- a/Sources/StringExtension.swift
+++ b/Sources/StringExtension.swift
@@ -103,7 +103,11 @@ extension String {
         return Regex.test(self, regex: Regex.imagePattern)
 
     }
-    
+
+    func isOpenGraphImage() -> Bool {
+        return Regex.test(self, regex: Regex.openGraphImagePattern)
+    }
+     
     func isVideo() -> Bool {
         return Regex.test(self, regex: Regex.videoTagPattern)
     }

--- a/Sources/SwiftLinkPreview.swift
+++ b/Sources/SwiftLinkPreview.swift
@@ -556,7 +556,7 @@ extension SwiftLinkPreview {
                             let value = value.decoded.extendedTrim
                             if tag == "image" {
                                 let value = addImagePrefixIfNeeded(value, result: result)
-                                if value.isImage() { result.set(value, for: key) }
+                                if value.isOpenGraphImage(){ result.set(value, for: key) }
                             } else if tag == "video" {
                                 let value = addImagePrefixIfNeeded(value, result: result)
                                 if value.isVideo() { result.set(value, for: key) }
@@ -621,20 +621,22 @@ extension SwiftLinkPreview {
             let images = result.images
 
             if images == nil || images?.isEmpty ?? true {
-                let values = Regex.pregMatchAll(htmlCode, regex: Regex.imageTagPattern, index: 2)
-                if !values.isEmpty {
-                    let imgs = values.map { self.addImagePrefixIfNeeded($0, result: result) }
 
-                    result.images = imgs
-                    result.image = imgs.first
-                }
-                else{
-                    let values = Regex.pregMatchAll(htmlCode, regex: Regex.secondaryImageTagPattern, index: 1)
+                // Should look for <meta property="og:image" content=""/> first instead of <img/> tag.
+                let values = Regex.pregMatchAll(htmlCode, regex: Regex.secondaryImageTagPattern, index: 1)
+                if !values.isEmpty {
+                    result.images = values
+                    result.image = values.first
+                } else {
+                    // If no OpenGraph image found pick any from <img/> tag to show.
+                    let values = Regex.pregMatchAll(htmlCode, regex: Regex.imageTagPattern, index: 2)
                     if !values.isEmpty {
-                        result.images = values
-                        result.image = values.first
+                        let imgs = values.map { self.addImagePrefixIfNeeded($0, result: result) }
+                        result.images = imgs
+                        result.image = imgs.first
                     }
                 }
+
             }
         } else {
                 let values = Regex.pregMatchAll(htmlCode, regex: Regex.secondaryImageTagPattern, index: 1)


### PR DESCRIPTION
<!-- Thanks for contributing to SwiftLinkPreview 😀 -->

<!--- Please follow the guideline below for better maintenance -->

<!-- Change the action with the following types: Added|Removed|Updated|Fixed or something alike. Group them by type. -->

#### Fixed 
- **Description:**  Invalid response image attribute in case of any GitHub URL
- **Issue:**  #144 
- **Commit:**  4701a0ebb9915349c7d57edd582093fb2e5df9d0


- **Changelog**
	- Basically, the meta tag containing the target image in GitHub site looks like this. It has no extension as stated below.

	- So, this image pattern used for this particular case cant detect it.

		- ```static let imagePattern = "(.+?)\\.(gif|jpg|jpeg|png|bmp)$"```

	- Also, first checking for "og:image" tag gets the right image as tested.

```
Sample Meta tag for target image in Github

<meta property="og:image" content="https://opengraph.githubassets.com/404e27b179d006746f87a82d651eba1e24a2dd7babd8
7cb16db0a4d09879e08c/bitcoin/bitcoin" />

```
