### PR TITLE
Change Regex limit from 300000 to 1000000

### DIFF
--- a/Sources/Regex.swift
+++ b/Sources/Regex.swift
@@ -71,7 +71,7 @@ class Regex {
 
             var matches: [NSTextCheckingResult] = []
 
-            let limit = 300000
+            let limit = 1000000
 
             if string.count > limit {
                 string.split(by: limit).forEach {


### PR DESCRIPTION
<!-- Thanks for contributing to SwiftLinkPreview 😀 -->

<!--- Please follow the guideline below for a better maintenance -->

<!-- Change the action with the following types: Added|Removed|Updated|Fixed or something alike. Group them by type. -->
#### Action 

<!-- If there are issues related to your PR, besides adding a brief description, add the issues' number. -->
- Change Regex limit from 300000 to 1000000
	- Reason: Some Website split with limit 300000 characters, cause miss some important "meta" tags
- ...