### PR TITLE
Improve README.md documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ import SwiftLinkPreview
 
 // ...
 
-let slp = SwiftLinkPreview(session: URLSession = URLSession.shared,
-			   workQueue: DispatchQueue = SwiftLinkPreview.defaultWorkQueue,
-			   responseQueue: DispatchQueue = DispatchQueue.main,
-		           cache: Cache = DisabledCache.instance)
+let slp = SwiftLinkPreview(session: URLSession.shared,
+			   workQueue: SwiftLinkPreview.defaultWorkQueue,
+			   responseQueue: DispatchQueue.main,
+		           cache: DisabledCache.instance)
 ```
 
 #### Requesting preview


### PR DESCRIPTION
The "Instantiation" section of "Usage" contains initialization code that does not work. Specifying types are done in class implementation. While displaying the types can be useful, they can cause confusion with the reader.