### PR TITLE
infinite refresh redirection issue fix

### DIFF
--- a/Sources/StringExtension.swift
+++ b/Sources/StringExtension.swift
@@ -82,6 +82,13 @@ extension String {
     }
 
     // Substring
+    
+    func getSubstring(_ start: Int, end: Int) -> String {
+        let startIndex = self.index(self.startIndex, offsetBy: start)
+        let endIndex = self.index(startIndex, offsetBy: end)
+        return String(self[startIndex..<endIndex])
+    }
+    
     func substring(_ start: Int, end: Int) -> String {
 
         return self.substring(NSRange(location: start, length: end - start))
@@ -100,27 +107,12 @@ extension String {
     // Check if url is an image
     func isImage() -> Bool {
 
-        let possible = ["gif", "jpg", "jpeg", "png", "bmp"]
-        if let url = URL(string: self),
-           possible.contains(url.pathExtension) {
-            return true
-        }
+        return Regex.test(self, regex: Regex.imagePattern)
 
-        return false
     }
-
-    func isOpenGraphImage() -> Bool {
-        return Regex.test(self, regex: Regex.openGraphImagePattern)
-    }
-     
+    
     func isVideo() -> Bool {
-        let possible = ["mp4", "mov", "mpeg", "avi", "m3u8"]
-        if let url = URL(string: self),
-           possible.contains(url.pathExtension) {
-            return true
-        }
-
-        return false
+        return Regex.test(self, regex: Regex.videoTagPattern)
     }
 
     // Split into substring of equal length


### PR DESCRIPTION
-> before fetching meta heads, removed any comment lines to ensure validy of tags
-> restricted redirection if title meta is present, assuming first fetched data has required information to fill up Response object
-> made sure redirect recursion only loops one time for faster response from completion
-> restricted max length of html string for faster performance, assuming meta tags are all available within half of the page
hope fixed #139 