### PR TITLE
FIXED: Amazon links did not contain og tags with the default user agent

### DIFF
--- a/SwiftLinkPreviewTests/HugeTests.swift
+++ b/SwiftLinkPreviewTests/HugeTests.swift
@@ -38,7 +38,7 @@ class HugeTests: XCTestCase {
     }
     
     // MARK: - Amazon
-    func testAmazonLinksWithDefaultUserAgent() {
+    func testAmazonLinksWithGoogleBotUserAgent() {
                     
         // Amazon links are huge and serve up very different html based on the user agent string
         // Some user agents don't contain og tags and will fail to locate title and images

--- a/SwiftLinkPreviewTests/HugeTests.swift
+++ b/SwiftLinkPreviewTests/HugeTests.swift
@@ -36,5 +36,60 @@ class HugeTests: XCTestCase {
         }
 
     }
+    
+    // MARK: - Amazon
+    func testAmazonLinksWithDefaultUserAgent() {
+                    
+        // Amazon links are huge and serve up very different html based on the user agent string
+        // Some user agents don't contain og tags and will fail to locate title and images
+        let amazonUrl = "https://www.amazon.com/Beginning-HTML5-CSS3-Dummies-Tittel/dp/1118657209/"
+        let expectation = self.expectation(description: "Loading web page")
+        var result:Response?
+        
+        let updatedSlp = SwiftLinkPreview(userAgent: SwiftLinkPreview.googleBotUserAgent)
+        
+        updatedSlp.preview(amazonUrl) {
+                        
+            result = $0
+            expectation.fulfill()
+            
+        } onError: { error in
+            
+            print(error)
+            XCTAssertNil(error)
+            
+        }
+
+        waitForExpectations(timeout: 15, handler: nil)
+        XCTAssert(!result!.title!.trim.isEmpty)
+        XCTAssertNotNil(result!.image)
+            
+    }
+    
+    func testAmazonLinksWithOriginalSlpUserAgent() {
+                    
+        // Amazon links are huge and serve up very different html based on the user agent string
+        // Some user agents don't contain og tags and will fail to locate title and images
+        let amazonUrl = "https://www.amazon.com/Beginning-HTML5-CSS3-Dummies-Tittel/dp/1118657209/"
+        let expectation = self.expectation(description: "Loading web page")
+        var result:Response?
+        
+        slp.preview(amazonUrl) {
+                        
+            result = $0
+            expectation.fulfill()
+            
+        } onError: { error in
+            
+            print(error)
+            XCTAssertNil(error)
+            
+        }
+
+        waitForExpectations(timeout: 15, handler: nil)
+        XCTAssert(!result!.title!.trim.isEmpty)
+        XCTAssertNil(result!.image)
+            
+    }
 
 }


### PR DESCRIPTION
#### Action 
ADDED: 'userAgent' with a default value to preserve current behavior
ADDED: 'googleBotUserAgent' static which can be used to override the default
ADDED: unit tests for Amazon links and tested across several other major ecommerce sites

NOTE: Not only does this fix OG tags for amazon.com links but the pages are way smaller due to Amazon optimizing for google search indexing (huge performance boost for preview response times)

- Made user agent a configurable property to optimize for some websites (Amazon was the driver for this)
	- Issues: none
	- Commits: 546b86e12ca38617483c922d1d355fe0e785ff40