### PR TITLE
Mark public structs Sendable and add an async preview function

### DIFF
--- a/Sources/PreviewError.swift
+++ b/Sources/PreviewError.swift
@@ -7,7 +7,7 @@
 //
 import Foundation
 
-public enum PreviewError: Error, CustomStringConvertible {
+public enum PreviewError: Error, Sendable, CustomStringConvertible {
     case noURLHasBeenFound(String?)
     case invalidURL(String?)
     case cannotBeOpened(String?)

--- a/Sources/Response.swift
+++ b/Sources/Response.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-public struct Response {
-    
+public struct Response: Sendable {
+
     public internal(set) var url: URL?
     public internal(set) var finalUrl: URL?
     public internal(set) var canonicalUrl: String?


### PR DESCRIPTION
#### Added

This adds an async overload for `preview` that handles cancellation and marks the public types as Sendable (their contents are already Sendable)

```
open func preview(_ text: String) async throws -> Response
```